### PR TITLE
Rethink moderation flow: private palettes + share-with-public

### DIFF
--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,2 +1,2 @@
-release: pip install -r requirements.txt
+release: pip install -r requirements.txt && cd database && PYTHONPATH=.. alembic upgrade head
 web: uvicorn main:app --host=0.0.0.0 --port=$PORT

--- a/backend/database/queries/palettes.py
+++ b/backend/database/queries/palettes.py
@@ -18,11 +18,14 @@ def hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
 
 
 def get_palettes_count(
-    moderation_status: ModerationStatus,
+    moderation_status: ModerationStatus | None = None,
     author_user_id: uuid.UUID | None = None,
 ) -> int:
     with Session(db_engine) as session:
-        query = session.query(Palette).filter(Palette.moderation_status == moderation_status)
+        query = session.query(Palette)
+
+        if moderation_status is not None:
+            query = query.filter(Palette.moderation_status == moderation_status)
 
         if author_user_id:
             query = query.filter(Palette.app_user_id == author_user_id)
@@ -53,8 +56,14 @@ def get_colors(size: int | None = None, offset: int | None = None) -> list[Palet
         return colors
 
 
+def _apply_moderation_filter(query, moderation_status: ModerationStatus | None):
+    if moderation_status is not None:
+        return query.filter(Palette.moderation_status == moderation_status)
+    return query
+
+
 def get_palettes(
-    moderation_status: ModerationStatus = ModerationStatus.APPROVED,
+    moderation_status: ModerationStatus | None = ModerationStatus.APPROVED,
     size: int | None = None,
     offset: int | None = None,
     author_user_id: uuid.UUID | None = None,
@@ -62,7 +71,6 @@ def get_palettes(
     color: str | None = None,
     app_user_id: uuid.UUID | None = None,
 ) -> list[Palette]:
-    print("got options", color)
     with Session(db_engine) as session:
         # Handle color-based sorting
         if sort_by == SortBy.COLOR and color:
@@ -94,10 +102,10 @@ def get_palettes(
                     )
                     .outerjoin(PaletteFavorite, Palette.id == PaletteFavorite.palette_id)
                     .options(joinedload(Palette.colors))
-                    .filter(Palette.moderation_status == moderation_status)
                     .group_by(Palette.id, color_distance_subquery.c.min_dist2)
                     .order_by(color_distance_subquery.c.min_dist2.asc())
                 )
+                query = _apply_moderation_filter(query, moderation_status)
             except (ValueError, AttributeError):
                 # Fallback to default sorting if color parsing fails
                 query = (
@@ -107,10 +115,10 @@ def get_palettes(
                     )
                     .outerjoin(PaletteFavorite, Palette.id == PaletteFavorite.palette_id)
                     .options(joinedload(Palette.colors))
-                    .filter(Palette.moderation_status == moderation_status)
                     .group_by(Palette.id)
                     .order_by(ORDER_BY.get(sort_by, Palette.created_at.asc()))
                 )
+                query = _apply_moderation_filter(query, moderation_status)
         else:
             query = (
                 session.query(
@@ -119,10 +127,10 @@ def get_palettes(
                 )
                 .outerjoin(PaletteFavorite, Palette.id == PaletteFavorite.palette_id)
                 .options(joinedload(Palette.colors))
-                .filter(Palette.moderation_status == moderation_status)
                 .group_by(Palette.id)
                 .order_by(ORDER_BY.get(sort_by, Palette.created_at.asc()))
             )
+            query = _apply_moderation_filter(query, moderation_status)
 
         if author_user_id:
             query = query.filter(Palette.app_user_id == author_user_id)

--- a/backend/routes/palettes/__init__.py
+++ b/backend/routes/palettes/__init__.py
@@ -7,6 +7,7 @@ from . import (
     get_palette_by_id,
     get_palette_list,
     get_palette_list_as_moderator,
+    make_private,
     moderate_palette,
     share_to_socials,
     submit_to_public,

--- a/backend/routes/palettes/__init__.py
+++ b/backend/routes/palettes/__init__.py
@@ -9,4 +9,5 @@ from . import (
     get_palette_list_as_moderator,
     moderate_palette,
     share_to_socials,
+    submit_to_public,
 )

--- a/backend/routes/palettes/create_palette.py
+++ b/backend/routes/palettes/create_palette.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from io import BytesIO
 
-from common.models import ImageWorkerActionEnum, Palette, PaletteColor, PermissionLevel
+from common.models import ImageWorkerActionEnum, ModerationStatus, Palette, PaletteColor, PermissionLevel
 from common.queries.worker import insert_image_worker
 from common.utils.photos import save_photo
 from fastapi import Form, UploadFile
@@ -64,6 +64,7 @@ def handle_request(
     name: str,
     parsed_palette: list[PaletteItem],
     request: RequestWithAuthState,
+    share_with_public: bool = False,
 ):
     palette_id = uuid.uuid4()
 
@@ -100,6 +101,10 @@ def handle_request(
             )
         )
 
+    moderation_status = (
+        ModerationStatus.AWAITING_MODERATION if share_with_public else ModerationStatus.PRIVATE
+    )
+
     new_palette = Palette(
         id=palette_id,
         name=name,
@@ -109,6 +114,7 @@ def handle_request(
         blurhash=blurhash,
         aspect_ratio=pil_image.width / pil_image.height,
         colors=colors,
+        moderation_status=moderation_status,
     )
 
     create_palette(new_palette)
@@ -120,7 +126,9 @@ def handle_request(
         json_data=None,
     )
 
-    send_pushover_notification(f"New palette submitted: {name}")
+    if share_with_public:
+        send_pushover_notification(f"New palette submitted: {name}")
+
     return SuccessResponse(
         paletteId=new_palette.id,
     )
@@ -132,6 +140,7 @@ async def create(
     image: UploadFile,
     name: str = Form(...),
     palette: str = Form(...),
+    share_with_public: bool = Form(False),
 ):
     if request.state.permission_level < PermissionLevel.MEMBER:
         return BaseErrorResponse(message=ErrorMsg.CANNOT_PERFORM_ACTION)
@@ -146,7 +155,7 @@ async def create(
         return BaseErrorResponse(message=str(e))
 
     try:
-        return handle_request(image, name, parsed_palette, request)
+        return handle_request(image, name, parsed_palette, request, share_with_public)
 
     except Exception as e:
         log_error(e, ROUTE_NAME)

--- a/backend/routes/palettes/get_palette_list.py
+++ b/backend/routes/palettes/get_palette_list.py
@@ -34,7 +34,7 @@ def calculate_can_see_all_moderation_statuses(
 def handle_request(
     size: int,
     offset: int,
-    moderation_status: ModerationStatus,
+    moderation_status: ModerationStatus | None,
     author_user_id: uuid.UUID | None,
     sort_by: SortBy,
     color: str | None,
@@ -44,14 +44,17 @@ def handle_request(
         app_user_id=app_user_id, author_user_id=author_user_id
     )
 
-    moderation_status = (
-        moderation_status if can_see_all_moderation_statuses else ModerationStatus.APPROVED
-    )
+    if can_see_all_moderation_statuses:
+        # Profile owner viewing own profile: use requested filter or show all
+        effective_status = moderation_status
+    else:
+        # Everyone else: only show approved palettes
+        effective_status = ModerationStatus.APPROVED
 
     palettes = get_palettes(
         size=size,
         offset=offset,
-        moderation_status=moderation_status,
+        moderation_status=effective_status,
         author_user_id=author_user_id,
         sort_by=sort_by,
         color=color,
@@ -59,7 +62,7 @@ def handle_request(
     )
 
     total_count = get_palettes_count(
-        moderation_status=moderation_status,
+        moderation_status=effective_status,
         author_user_id=author_user_id,
     )
     return SuccessResponse(
@@ -73,7 +76,7 @@ async def get_palette_list(
     request: RequestWithAuthState,
     size: int = Query(25, ge=1, le=100),
     offset: int = Query(0, ge=0),
-    moderation_status: ModerationStatus = ModerationStatus.APPROVED,
+    moderation_status: ModerationStatus | None = None,
     author_user_id: uuid.UUID | None = None,
     sort_by: SortBy = SortBy.NEWEST,
     color: str | None = None,

--- a/backend/routes/palettes/make_private.py
+++ b/backend/routes/palettes/make_private.py
@@ -1,0 +1,50 @@
+import uuid
+
+from common.models import ModerationStatus, Palette, PermissionLevel
+from common.queries.palettes import PaletteUpdate, update_palette
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from consts import ErrorMsg
+from database.engine import db_engine
+from middleware.auth import RequestWithAuthState
+from routes.shared import BaseErrorResponse, BaseSuccessResponse
+from services.logger import log_error
+
+from .palettes_router import palettes_router
+
+ROUTE_NAME = "make_private"
+
+
+class Body(BaseModel):
+    palette_id: uuid.UUID
+
+
+@palettes_router.post("/make_private")
+async def make_private(
+    request: RequestWithAuthState,
+    body: Body,
+):
+    if request.state.permission_level < PermissionLevel.MEMBER:
+        return BaseErrorResponse(message=ErrorMsg.CANNOT_PERFORM_ACTION)
+
+    try:
+        with Session(db_engine) as session:
+            palette = session.query(Palette).filter(Palette.id == body.palette_id).first()
+            if not palette:
+                return BaseErrorResponse(message=ErrorMsg.RESOURCE_NOT_FOUND)
+
+            if palette.app_user_id != request.state.app_user_id:
+                return BaseErrorResponse(message=ErrorMsg.CANNOT_PERFORM_ACTION)
+
+            if palette.moderation_status == ModerationStatus.PRIVATE:
+                return BaseErrorResponse(message="Palette is already private")
+
+        palette_update = PaletteUpdate(moderation_status=ModerationStatus.PRIVATE)
+        update_palette(db_engine=db_engine, palette_id=body.palette_id, update=palette_update)
+
+        return BaseSuccessResponse()
+
+    except Exception as error:
+        log_error(error, ROUTE_NAME)
+        return BaseErrorResponse(message=ErrorMsg.SOMETHING_WENT_WRONG)

--- a/backend/routes/palettes/submit_to_public.py
+++ b/backend/routes/palettes/submit_to_public.py
@@ -1,0 +1,52 @@
+import uuid
+
+from common.models import ModerationStatus, Palette, PermissionLevel
+from common.queries.palettes import PaletteUpdate, update_palette
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from consts import ErrorMsg
+from database.engine import db_engine
+from middleware.auth import RequestWithAuthState
+from routes.shared import BaseErrorResponse, BaseSuccessResponse
+from services.logger import log_error
+from services.pushover import send_pushover_notification
+
+from .palettes_router import palettes_router
+
+ROUTE_NAME = "submit_to_public"
+
+
+class Body(BaseModel):
+    palette_id: uuid.UUID
+
+
+@palettes_router.post("/submit_to_public")
+async def submit_to_public(
+    request: RequestWithAuthState,
+    body: Body,
+):
+    if request.state.permission_level < PermissionLevel.MEMBER:
+        return BaseErrorResponse(message=ErrorMsg.CANNOT_PERFORM_ACTION)
+
+    try:
+        with Session(db_engine) as session:
+            palette = session.query(Palette).filter(Palette.id == body.palette_id).first()
+            if not palette:
+                return BaseErrorResponse(message=ErrorMsg.RESOURCE_NOT_FOUND)
+
+            if palette.app_user_id != request.state.app_user_id:
+                return BaseErrorResponse(message=ErrorMsg.CANNOT_PERFORM_ACTION)
+
+            if palette.moderation_status != ModerationStatus.PRIVATE:
+                return BaseErrorResponse(message="Palette is not private")
+
+        palette_update = PaletteUpdate(moderation_status=ModerationStatus.AWAITING_MODERATION)
+        update_palette(db_engine=db_engine, palette_id=body.palette_id, update=palette_update)
+
+        send_pushover_notification(f"Palette submitted for review: {palette.name}")
+        return BaseSuccessResponse()
+
+    except Exception as error:
+        log_error(error, ROUTE_NAME)
+        return BaseErrorResponse(message=ErrorMsg.SOMETHING_WENT_WRONG)

--- a/common/common/models.py
+++ b/common/common/models.py
@@ -88,6 +88,7 @@ class ModerationStatus(IntEnum):
     AWAITING_MODERATION = 0
     APPROVED = 1
     REJECTED = 2
+    PRIVATE = 3
 
 
 class SortBy(Enum):

--- a/database/alembic/versions/f1a2b3c4d5e6_add_private_moderation_status.py
+++ b/database/alembic/versions/f1a2b3c4d5e6_add_private_moderation_status.py
@@ -1,0 +1,28 @@
+"""add_private_moderation_status
+
+Revision ID: f1a2b3c4d5e6
+Revises: 55369f1fb9fe
+Create Date: 2026-03-14
+
+"""
+
+from typing import Sequence, Union
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f1a2b3c4d5e6"
+down_revision: Union[str, None] = "55369f1fb9fe"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ModerationStatus is stored as an Integer column, so no DDL change needed.
+    # This migration documents the addition of PRIVATE = 3 to the ModerationStatus enum.
+    pass
+
+
+def downgrade() -> None:
+    # No DDL to reverse. Any palettes with moderation_status=3 would need
+    # to be updated manually before downgrading.
+    pass

--- a/designs/moderation-rethink/SCOPES.yml
+++ b/designs/moderation-rethink/SCOPES.yml
@@ -14,141 +14,29 @@ tasks:
   - id: 1
     milestone: 1
     title: Add PRIVATE moderation status and database migration
-    description: |
-      Add `PRIVATE = 3` to the `ModerationStatus` IntEnum in `common/common/models.py`.
-      Create an Alembic migration documenting the new status value.
-      Since ModerationStatus is stored as an Integer column, no DDL change is needed —
-      the migration just documents the new valid value.
-      No existing palette data changes.
-    acceptance_criteria:
-      - ModerationStatus.PRIVATE exists with value 3
-      - An Alembic migration is created
-      - Existing tests still pass
-    depends_on: []
-    effort: 1
-    status: implementing
+    status: completed
 
   - id: 2
     milestone: 1
     title: Update create_palette to accept share_with_public parameter
-    description: |
-      Update `POST /palettes/create` to accept an optional `share_with_public` boolean
-      form field (defaults to `false`).
-
-      - If `share_with_public=true`: set `moderation_status = AWAITING_MODERATION` (current behavior)
-      - If `share_with_public=false`: set `moderation_status = PRIVATE`
-
-      Only send pushover notification when `share_with_public=true`, since private
-      palettes don't need moderator attention.
-
-      Key file: `backend/routes/palettes/create_palette.py`
-    acceptance_criteria:
-      - Endpoint accepts share_with_public boolean form field (default false)
-      - share_with_public=false creates palette with moderation_status=PRIVATE
-      - share_with_public=true creates palette with moderation_status=AWAITING_MODERATION
-      - Pushover notification only sent when share_with_public=true
-    depends_on: [1]
-    effort: 1
-    status: scoped
+    status: completed
 
   - id: 3
     milestone: 1
     title: Update get_palette_list for unified profile view
-    description: |
-      Update `GET /palettes` so the profile owner can fetch all their palettes
-      in a single request (all statuses combined) instead of requiring tab-based
-      moderation_status filtering.
-
-      Changes:
-      - Make `moderation_status` parameter optional (default None instead of APPROVED)
-      - When None and user is viewing own profile: return all statuses
-      - When None and viewing others or browsing: return only APPROVED
-      - PRIVATE palettes must never be visible to anyone except the owner
-      - Update `get_palettes` and `get_palettes_count` queries to handle None status
-
-      Key files:
-      - `backend/routes/palettes/get_palette_list.py`
-      - `backend/database/queries/palettes.py` and/or `common/common/queries/palettes.py`
-    acceptance_criteria:
-      - Profile owner can fetch all their palettes in a single request by omitting moderation_status
-      - Non-owners and unauthenticated users only see APPROVED palettes
-      - PRIVATE palettes never visible to non-owners
-      - Browse page still defaults to APPROVED only
-    depends_on: [1]
-    effort: 2
-    status: scoped
+    status: completed
 
   - id: 4
     milestone: 1
     title: Update frontend types and createPalette API call
-    description: |
-      Update frontend types and API call to support the new flow.
-
-      `frontend/src/types.ts`:
-      - Add `PRIVATE: 3` to MODERATION_STATUS
-      - Add `'Private'` label to MODERATION_STATUS_LABEL
-
-      `frontend/src/api/palettes/createPalette.ts`:
-      - Add `shareWithPublic: boolean` to the function params
-      - Append `share_with_public` to the FormData sent to the backend
-    acceptance_criteria:
-      - MODERATION_STATUS includes PRIVATE with value 3
-      - MODERATION_STATUS_LABEL includes label for PRIVATE
-      - createPalette API call sends share_with_public in FormData
-    depends_on: []
-    effort: 1
-    status: scoped
+    status: completed
 
   - id: 5
     milestone: 1
     title: Add share-with-public checkbox to Create page
-    description: |
-      Add a "Share with public" checkbox to the Create page's save section
-      (both desktop and mobile layouts).
-
-      - Checkbox is unchecked by default
-      - Below the checkbox, show helper text: "Your palette will be reviewed and may be featured on the public browse page"
-      - Pass the checkbox value through to `createPalette` API call
-      - Update the confirmation modal message:
-        - If shared: "Thanks for your submission! Once approved, it will appear on the browse page."
-        - If private: "Palette saved to your library!"
-
-      Key file: `frontend/src/pages/Create/Create.tsx`
-    acceptance_criteria:
-      - Checkbox labeled "Share with public" appears near the Save button in both layouts
-      - Helper text shown below checkbox explaining the review process
-      - Checkbox value passed to createPalette API
-      - Confirmation modal message differs based on share choice
-    depends_on: [4]
-    effort: 2
-    status: scoped
+    status: completed
 
   - id: 6
     milestone: 1
     title: Redesign Profile page - remove tabs, add status indicators
-    description: |
-      Replace the tab-based profile layout with a unified list showing all
-      of the user's palettes with status indicators.
-
-      Own profile:
-      - Remove the MUI Tabs component
-      - Show all palettes in a single list sorted by newest
-      - Add a small status chip/badge on each PaletteThumbnail indicating:
-        Private, Pending Review, Public, or Rejected
-      - Query the backend with no moderation_status filter (relies on task 3)
-
-      Other users' profiles:
-      - No change needed — backend already returns only APPROVED palettes
-      - No status badges shown (all visible palettes are public)
-
-      Key files:
-      - `frontend/src/pages/Profile.tsx` — Remove tabs, update query, add status display
-      - `frontend/src/sharedComponents/PaletteThumbnail.tsx` — Add optional status badge prop
-    acceptance_criteria:
-      - Own profile shows all palettes in a single unified list
-      - Each palette on own profile has a status indicator (Private/Pending/Public/Rejected)
-      - No tabs on the profile page
-      - Other users' profiles still show only approved palettes with no status badges
-    depends_on: [4]
-    effort: 3
-    status: scoped
+    status: completed

--- a/designs/moderation-rethink/SCOPES.yml
+++ b/designs/moderation-rethink/SCOPES.yml
@@ -1,0 +1,154 @@
+project: Moderation Flow Rethink
+repo: travisbumgarner/photo-palettes
+scoping_date: 2026-03-14
+
+milestones:
+  - number: 1
+    title: "1. Private palettes and share-with-public flow"
+    description: Add PRIVATE moderation status, update backend and frontend to support share-with-public opt-in, redesign profile page
+    branch:
+      working: moderation-rethink
+      base: main
+
+tasks:
+  - id: 1
+    milestone: 1
+    title: Add PRIVATE moderation status and database migration
+    description: |
+      Add `PRIVATE = 3` to the `ModerationStatus` IntEnum in `common/common/models.py`.
+      Create an Alembic migration documenting the new status value.
+      Since ModerationStatus is stored as an Integer column, no DDL change is needed —
+      the migration just documents the new valid value.
+      No existing palette data changes.
+    acceptance_criteria:
+      - ModerationStatus.PRIVATE exists with value 3
+      - An Alembic migration is created
+      - Existing tests still pass
+    depends_on: []
+    effort: 1
+    status: implementing
+
+  - id: 2
+    milestone: 1
+    title: Update create_palette to accept share_with_public parameter
+    description: |
+      Update `POST /palettes/create` to accept an optional `share_with_public` boolean
+      form field (defaults to `false`).
+
+      - If `share_with_public=true`: set `moderation_status = AWAITING_MODERATION` (current behavior)
+      - If `share_with_public=false`: set `moderation_status = PRIVATE`
+
+      Only send pushover notification when `share_with_public=true`, since private
+      palettes don't need moderator attention.
+
+      Key file: `backend/routes/palettes/create_palette.py`
+    acceptance_criteria:
+      - Endpoint accepts share_with_public boolean form field (default false)
+      - share_with_public=false creates palette with moderation_status=PRIVATE
+      - share_with_public=true creates palette with moderation_status=AWAITING_MODERATION
+      - Pushover notification only sent when share_with_public=true
+    depends_on: [1]
+    effort: 1
+    status: scoped
+
+  - id: 3
+    milestone: 1
+    title: Update get_palette_list for unified profile view
+    description: |
+      Update `GET /palettes` so the profile owner can fetch all their palettes
+      in a single request (all statuses combined) instead of requiring tab-based
+      moderation_status filtering.
+
+      Changes:
+      - Make `moderation_status` parameter optional (default None instead of APPROVED)
+      - When None and user is viewing own profile: return all statuses
+      - When None and viewing others or browsing: return only APPROVED
+      - PRIVATE palettes must never be visible to anyone except the owner
+      - Update `get_palettes` and `get_palettes_count` queries to handle None status
+
+      Key files:
+      - `backend/routes/palettes/get_palette_list.py`
+      - `backend/database/queries/palettes.py` and/or `common/common/queries/palettes.py`
+    acceptance_criteria:
+      - Profile owner can fetch all their palettes in a single request by omitting moderation_status
+      - Non-owners and unauthenticated users only see APPROVED palettes
+      - PRIVATE palettes never visible to non-owners
+      - Browse page still defaults to APPROVED only
+    depends_on: [1]
+    effort: 2
+    status: scoped
+
+  - id: 4
+    milestone: 1
+    title: Update frontend types and createPalette API call
+    description: |
+      Update frontend types and API call to support the new flow.
+
+      `frontend/src/types.ts`:
+      - Add `PRIVATE: 3` to MODERATION_STATUS
+      - Add `'Private'` label to MODERATION_STATUS_LABEL
+
+      `frontend/src/api/palettes/createPalette.ts`:
+      - Add `shareWithPublic: boolean` to the function params
+      - Append `share_with_public` to the FormData sent to the backend
+    acceptance_criteria:
+      - MODERATION_STATUS includes PRIVATE with value 3
+      - MODERATION_STATUS_LABEL includes label for PRIVATE
+      - createPalette API call sends share_with_public in FormData
+    depends_on: []
+    effort: 1
+    status: scoped
+
+  - id: 5
+    milestone: 1
+    title: Add share-with-public checkbox to Create page
+    description: |
+      Add a "Share with public" checkbox to the Create page's save section
+      (both desktop and mobile layouts).
+
+      - Checkbox is unchecked by default
+      - Below the checkbox, show helper text: "Your palette will be reviewed and may be featured on the public browse page"
+      - Pass the checkbox value through to `createPalette` API call
+      - Update the confirmation modal message:
+        - If shared: "Thanks for your submission! Once approved, it will appear on the browse page."
+        - If private: "Palette saved to your library!"
+
+      Key file: `frontend/src/pages/Create/Create.tsx`
+    acceptance_criteria:
+      - Checkbox labeled "Share with public" appears near the Save button in both layouts
+      - Helper text shown below checkbox explaining the review process
+      - Checkbox value passed to createPalette API
+      - Confirmation modal message differs based on share choice
+    depends_on: [4]
+    effort: 2
+    status: scoped
+
+  - id: 6
+    milestone: 1
+    title: Redesign Profile page - remove tabs, add status indicators
+    description: |
+      Replace the tab-based profile layout with a unified list showing all
+      of the user's palettes with status indicators.
+
+      Own profile:
+      - Remove the MUI Tabs component
+      - Show all palettes in a single list sorted by newest
+      - Add a small status chip/badge on each PaletteThumbnail indicating:
+        Private, Pending Review, Public, or Rejected
+      - Query the backend with no moderation_status filter (relies on task 3)
+
+      Other users' profiles:
+      - No change needed — backend already returns only APPROVED palettes
+      - No status badges shown (all visible palettes are public)
+
+      Key files:
+      - `frontend/src/pages/Profile.tsx` — Remove tabs, update query, add status display
+      - `frontend/src/sharedComponents/PaletteThumbnail.tsx` — Add optional status badge prop
+    acceptance_criteria:
+      - Own profile shows all palettes in a single unified list
+      - Each palette on own profile has a status indicator (Private/Pending/Public/Rejected)
+      - No tabs on the profile page
+      - Other users' profiles still show only approved palettes with no status badges
+    depends_on: [4]
+    effort: 3
+    status: scoped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
   db:
     image: postgres:15
     ports:
-      - "5432:5432"
+      - "5433:5432"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - "3000:3000"
     volumes:
       - ./frontend:/app
-      - frontend_node_modules:/app/node_modules
+      - /app/node_modules
     env_file:
       - ./frontend/.env.development
 
@@ -62,10 +62,4 @@ services:
       timeout: 5s
       retries: 5
 
-volumes:
-  frontend_node_modules:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: ./frontend/node_modules
+volumes: {}

--- a/frontend/src/api/palettes/createPalette.ts
+++ b/frontend/src/api/palettes/createPalette.ts
@@ -18,10 +18,12 @@ export const createPalette = async ({
   generatedPalette,
   name,
   image,
+  shareWithPublic,
 }: {
   generatedPalette: TGeneratedPalette
   name: string
   image: Blob
+  shareWithPublic: boolean
 }) => {
   const tokenResponse = await getToken()
 
@@ -46,6 +48,7 @@ export const createPalette = async ({
     )
   )
   formData.append('image', image)
+  formData.append('share_with_public', String(shareWithPublic))
 
   const response = await fetch(`${config.apiUrl}/palettes/create`, {
     method: 'POST',

--- a/frontend/src/api/palettes/makePrivate.ts
+++ b/frontend/src/api/palettes/makePrivate.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+import config from '../../config'
+import { getToken } from '../../services/supabase'
+
+const zodResponse = z.discriminatedUnion('success', [
+  z.object({
+    success: z.literal(true),
+  }),
+  z.object({
+    success: z.literal(false),
+    message: z.string(),
+  }),
+])
+
+export const makePrivate = async ({
+  paletteId,
+}: {
+  paletteId: string
+}) => {
+  const tokenResponse = await getToken()
+
+  if (!tokenResponse.success)
+    return {
+      success: false,
+      message: 'No token found',
+    } as const
+
+  const response = await fetch(`${config.apiUrl}/palettes/make_private`, {
+    method: 'POST',
+    body: JSON.stringify({ palette_id: paletteId }),
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${tokenResponse.token}`,
+    },
+  })
+
+  const data = await response.json()
+  return zodResponse.parse(data)
+}

--- a/frontend/src/api/palettes/submitToPublic.ts
+++ b/frontend/src/api/palettes/submitToPublic.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+import config from '../../config'
+import { getToken } from '../../services/supabase'
+
+const zodResponse = z.discriminatedUnion('success', [
+  z.object({
+    success: z.literal(true),
+  }),
+  z.object({
+    success: z.literal(false),
+    message: z.string(),
+  }),
+])
+
+export const submitToPublic = async ({
+  paletteId,
+}: {
+  paletteId: string
+}) => {
+  const tokenResponse = await getToken()
+
+  if (!tokenResponse.success)
+    return {
+      success: false,
+      message: 'No token found',
+    } as const
+
+  const response = await fetch(`${config.apiUrl}/palettes/submit_to_public`, {
+    method: 'POST',
+    body: JSON.stringify({ palette_id: paletteId }),
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${tokenResponse.token}`,
+    },
+  })
+
+  const data = await response.json()
+  return zodResponse.parse(data)
+}

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -105,7 +105,8 @@ const About = () => {
         <Typography variant="body1" sx={{ textAlign: 'center' }}>
           Generate beautiful color palettes from your photos. Whether you're a
           designer, artist, or just love colors, Photo Palettes helps you extract
-          and share stunning color combinations from any image.
+          stunning color combinations from any image. Save palettes to your
+          private library or share them with the community.
         </Typography>
       </Box>
 
@@ -145,7 +146,7 @@ const About = () => {
         See It In Action
       </Typography>
 
-      <ScreenshotPlaceholder image="public/marketing/create.png" strongText="Create" text="Choose a pre-defined palette or create your own." />
+      <ScreenshotPlaceholder image="public/marketing/create.png" strongText="Create" text="Choose a pre-defined palette or create your own. Keep it private or share it with the community." />
       <ScreenshotPlaceholder image="public/marketing/search.png" strongText="Get Inspired" text="Find palettes by color, popularity, or recency. Save your favorites." />
       <ScreenshotPlaceholder image="public/marketing/explore2.png" strongText="Dive Deep" text="Use any palette as a starting point to explore the color wheel." />
 
@@ -164,7 +165,7 @@ const About = () => {
           Get Started
         </Typography>
         <Typography variant="body1" sx={{ textAlign: 'center' }}>
-          Create your free account to save palettes and join our community.
+          Create your free account to build your private palette library or share your creations with the community.
         </Typography>
         <Box sx={{ display: 'flex', gap: SPACING.MEDIUM.PX, flexWrap: 'wrap', justifyContent: 'center' }}>
           <Button

--- a/frontend/src/pages/Create/Create.tsx
+++ b/frontend/src/pages/Create/Create.tsx
@@ -1,6 +1,8 @@
 import { Capacitor } from '@capacitor/core'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
+import Checkbox from '@mui/material/Checkbox'
+import FormControlLabel from '@mui/material/FormControlLabel'
 import { styled, type SxProps } from '@mui/material/styles'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
@@ -65,6 +67,7 @@ const Create = ({ mode }: { mode: 'lite' | 'full' }) => {
   const [paletteSortOrder, setPaletteSortOrder] = useState<number[]>(
     Array.from({ length: PALETTE_SIZE }, (_, i) => i)
   )
+  const [shareWithPublic, setShareWithPublic] = useState(false)
   const [tempId, setTempId] = useState<string | null>(null)
   useEffect(() => {
     // When the user is signed out, they can create palettes.
@@ -235,6 +238,7 @@ const Create = ({ mode }: { mode: 'lite' | 'full' }) => {
       generatedPalette: sortedPalette,
       name,
       image: photo,
+      shareWithPublic,
     })
 
     if (response.success) {
@@ -242,8 +246,12 @@ const Create = ({ mode }: { mode: 'lite' | 'full' }) => {
       activeModalSignal.value = {
         id: MODAL_ID.CONFIRMATION_MODAL,
         confirmationCallback: () => handleSaveFullCallback(response.paletteId),
-        title: 'Thanks for your submission!',
-        body: 'Once it is approved, it will be added to the site.',
+        title: shareWithPublic
+          ? 'Thanks for your submission!'
+          : 'Palette saved!',
+        body: shareWithPublic
+          ? 'Once approved, it will appear on the browse page.'
+          : 'Your palette has been saved to your library.',
       }
       setCreationStatus('SUBMITTED')
     } else {
@@ -256,6 +264,7 @@ const Create = ({ mode }: { mode: 'lite' | 'full' }) => {
     palette,
     paletteSortOrder,
     photo,
+    shareWithPublic,
     tempId,
   ])
 
@@ -369,6 +378,24 @@ const Create = ({ mode }: { mode: 'lite' | 'full' }) => {
                 </SectionWrapper>
 
                 <SectionWrapper>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={shareWithPublic}
+                        onChange={(e) => setShareWithPublic(e.target.checked)}
+                        size="small"
+                      />
+                    }
+                    label="Share with public"
+                  />
+                  {shareWithPublic && (
+                    <Typography variant="caption" color="text.secondary">
+                      Your palette will be reviewed and may be featured on the public browse page
+                    </Typography>
+                  )}
+                </SectionWrapper>
+
+                <SectionWrapper>
                   <Box
                     sx={{
                       display: 'flex',
@@ -415,6 +442,24 @@ const Create = ({ mode }: { mode: 'lite' | 'full' }) => {
                   value={name}
                   onChange={handleNameChange}
                 />
+              </SectionWrapper>
+
+              <SectionWrapper>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={shareWithPublic}
+                      onChange={(e) => setShareWithPublic(e.target.checked)}
+                      size="small"
+                    />
+                  }
+                  label="Share with public"
+                />
+                {shareWithPublic && (
+                  <Typography variant="caption" color="text.secondary">
+                    Your palette will be reviewed and may be featured on the public browse page
+                  </Typography>
+                )}
               </SectionWrapper>
 
               <SectionWrapper>

--- a/frontend/src/pages/Palette/Palette.tsx
+++ b/frontend/src/pages/Palette/Palette.tsx
@@ -51,6 +51,13 @@ const Palette = () => {
 
   return (
     <>
+      {data.palette.moderationStatus === MODERATION_STATUS.PRIVATE && (
+        <Message
+          includeVerticalMargin
+          message="This palette is in your private library."
+          color="info"
+        />
+      )}
       {data.palette.moderationStatus ===
         MODERATION_STATUS.AWAITING_MODERATION && (
         <Message

--- a/frontend/src/pages/Palette/components/Summary.tsx
+++ b/frontend/src/pages/Palette/components/Summary.tsx
@@ -52,37 +52,38 @@ const Summary = ({
           {getUserColorFromUUID(appUserId)}
         </Link>
 
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-          {isOwner && isPrivate && (
-            <Button
-              variant="outlined"
-              size="small"
-              disabled={submitMutation.isPending}
-              onClick={() => submitMutation.mutate()}
-            >
-              Share with public
-            </Button>
-          )}
-          {isOwner && !isPrivate && (
-            <Button
-              variant="outlined"
-              size="small"
-              disabled={makePrivateMutation.isPending}
-              onClick={() => makePrivateMutation.mutate()}
-            >
-              Make private
-            </Button>
-          )}
-          {!isPrivate && (
-            <Favorite
-              refetch={refetch}
-              paletteId={id}
-              favorites={favoritesCount}
-              hasUserFavorited={hasUserFavorited}
-            />
-          )}
-        </Box>
+        {!isPrivate && (
+          <Favorite
+            refetch={refetch}
+            paletteId={id}
+            favorites={favoritesCount}
+            hasUserFavorited={hasUserFavorited}
+          />
+        )}
       </Box>
+
+      {isOwner && isPrivate && (
+        <Button
+          variant="outlined"
+          size="small"
+          fullWidth
+          disabled={submitMutation.isPending}
+          onClick={() => submitMutation.mutate()}
+        >
+          Share with public
+        </Button>
+      )}
+      {isOwner && !isPrivate && (
+        <Button
+          variant="outlined"
+          size="small"
+          fullWidth
+          disabled={makePrivateMutation.isPending}
+          onClick={() => makePrivateMutation.mutate()}
+        >
+          Make private
+        </Button>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/Palette/components/Summary.tsx
+++ b/frontend/src/pages/Palette/components/Summary.tsx
@@ -1,6 +1,7 @@
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import { useMutation } from '@tanstack/react-query'
+import { makePrivate } from '../../../api/palettes/makePrivate'
 import { submitToPublic } from '../../../api/palettes/submitToPublic'
 import Favorite from '../../../sharedComponents/Favorite'
 import Link from '../../../sharedComponents/Link'
@@ -23,6 +24,13 @@ const Summary = ({
 
   const submitMutation = useMutation({
     mutationFn: () => submitToPublic({ paletteId: id }),
+    onSuccess: (data) => {
+      if (data.success) refetch()
+    },
+  })
+
+  const makePrivateMutation = useMutation({
+    mutationFn: () => makePrivate({ paletteId: id }),
     onSuccess: (data) => {
       if (data.success) refetch()
     },
@@ -53,6 +61,16 @@ const Summary = ({
               onClick={() => submitMutation.mutate()}
             >
               Share with public
+            </Button>
+          )}
+          {isOwner && !isPrivate && (
+            <Button
+              variant="outlined"
+              size="small"
+              disabled={makePrivateMutation.isPending}
+              onClick={() => makePrivateMutation.mutate()}
+            >
+              Make private
             </Button>
           )}
           {!isPrivate && (

--- a/frontend/src/pages/Palette/components/Summary.tsx
+++ b/frontend/src/pages/Palette/components/Summary.tsx
@@ -1,18 +1,33 @@
 import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import { useMutation } from '@tanstack/react-query'
+import { submitToPublic } from '../../../api/palettes/submitToPublic'
 import Favorite from '../../../sharedComponents/Favorite'
 import Link from '../../../sharedComponents/Link'
+import useGlobalStore from '../../../store'
 import PageTitle from '../../../styles/shared/PageTitle'
-import { type TPalette } from '../../../types'
+import { MODERATION_STATUS, type TPalette } from '../../../types'
 import { getUserColorFromUUID } from '../../../utils/getUserColorFromUUID'
 
 const Summary = ({
-  palette: { name, appUserId, favoritesCount, hasUserFavorited, id },
+  palette: { name, appUserId, favoritesCount, hasUserFavorited, id, moderationStatus },
   refetch,
 }: {
   isMobile: boolean
   palette: TPalette
   refetch: () => void
 }) => {
+  const appUser = useGlobalStore((state) => state.appUser)
+  const isOwner = appUser?.id === appUserId
+  const isPrivate = moderationStatus === MODERATION_STATUS.PRIVATE
+
+  const submitMutation = useMutation({
+    mutationFn: () => submitToPublic({ paletteId: id }),
+    onSuccess: (data) => {
+      if (data.success) refetch()
+    },
+  })
+
   return (
     <div>
       <PageTitle text={name} />
@@ -29,13 +44,25 @@ const Summary = ({
           {getUserColorFromUUID(appUserId)}
         </Link>
 
-        <Box>
-          <Favorite
-            refetch={refetch}
-            paletteId={id}
-            favorites={favoritesCount}
-            hasUserFavorited={hasUserFavorited}
-          />
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          {isOwner && isPrivate && (
+            <Button
+              variant="outlined"
+              size="small"
+              disabled={submitMutation.isPending}
+              onClick={() => submitMutation.mutate()}
+            >
+              Share with public
+            </Button>
+          )}
+          {!isPrivate && (
+            <Favorite
+              refetch={refetch}
+              paletteId={id}
+              favorites={favoritesCount}
+              hasUserFavorited={hasUserFavorited}
+            />
+          )}
         </Box>
       </Box>
     </div>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,7 +1,6 @@
-import Tab from '@mui/material/Tab'
-import Tabs from '@mui/material/Tabs'
+import Chip from '@mui/material/Chip'
 import { useQuery } from '@tanstack/react-query'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import getPaletteList from '../api/palettes/getPaletteList'
 import { PAGINATION_SIZE, ROUTES } from '../consts'
@@ -19,15 +18,16 @@ import { SPACING } from '../styles/styleConsts'
 import { MODERATION_STATUS, MODERATION_STATUS_LABEL, SORT_BY } from '../types'
 import { getContrastColor } from '../utils/getContrastColor'
 import { getUserColorFromUUID } from '../utils/getUserColorFromUUID'
+import { useState } from 'react'
 
-const STATUS_TABS = [
-  MODERATION_STATUS.APPROVED,
-  MODERATION_STATUS.AWAITING_MODERATION,
-  MODERATION_STATUS.REJECTED,
-]
+const STATUS_CHIP_COLOR: Record<number, 'default' | 'success' | 'warning' | 'error' | 'info'> = {
+  [MODERATION_STATUS.PRIVATE]: 'default',
+  [MODERATION_STATUS.AWAITING_MODERATION]: 'warning',
+  [MODERATION_STATUS.APPROVED]: 'success',
+  [MODERATION_STATUS.REJECTED]: 'error',
+}
 
 const Profile = () => {
-  const [filterTabIndex, setFilterTabIndex] = useState(0)
   const params = useParams()
   const [page, setPage] = useState(1)
   const navigate = useNavigate()
@@ -36,14 +36,15 @@ const Profile = () => {
   const authorUserId =
     (Array.isArray(params.id) ? params.id[0] : params.id) || appUser?.id || ''
 
+  const isProfileUser = authorUserId === appUser?.id
+
   const { data, isLoading, error, refetch } = useQuery({
-    queryKey: ['profile', authorUserId, filterTabIndex, page],
+    queryKey: ['profile', authorUserId, page],
     queryFn: () =>
       getPaletteList({
         size: PAGINATION_SIZE,
         offset: (page - 1) * PAGINATION_SIZE,
         authorUserId,
-        moderationStatus: STATUS_TABS[filterTabIndex],
         sortBy: SORT_BY.NEWEST,
       }),
     retry: false,
@@ -71,11 +72,6 @@ const Profile = () => {
     }
   }, [authorUserId, navigate])
 
-  const handleTabChange = useCallback((_event: unknown, v: number) => {
-    setFilterTabIndex(v)
-    setPage(1)
-  }, [])
-
   useEffect(() => {
     if (error) {
       logger.error('Error fetching profile palettes', error, data?.success)
@@ -98,6 +94,16 @@ const Profile = () => {
               refetch={refetch}
               key={palette.id}
               palette={palette}
+              statusChip={
+                isProfileUser ? (
+                  <Chip
+                    label={MODERATION_STATUS_LABEL[palette.moderationStatus]}
+                    color={STATUS_CHIP_COLOR[palette.moderationStatus] ?? 'default'}
+                    size="small"
+                    variant="outlined"
+                  />
+                ) : undefined
+              }
             />
           ))}
         </ThumbnailGridDisplay>
@@ -108,9 +114,7 @@ const Profile = () => {
         />
       </>
     )
-  }, [data, error, isLoading, handlePageChange, page, refetch])
-
-  const isProfileUser = authorUserId === appUser?.id
+  }, [data, error, isLoading, handlePageChange, page, refetch, isProfileUser])
 
   const displayName = getUserColorFromUUID(authorUserId)
 
@@ -128,22 +132,6 @@ const Profile = () => {
           alignSelf: 'flex-start',
         }}
       />
-      {isProfileUser && (
-        <Tabs
-          variant="scrollable"
-          value={filterTabIndex}
-          onChange={handleTabChange}
-          sx={{ marginBottom: SPACING.MEDIUM.PX }}
-        >
-          {STATUS_TABS.map((key) => (
-            <Tab
-              disabled={isLoading}
-              key={key}
-              label={MODERATION_STATUS_LABEL[key]}
-            />
-          ))}
-        </Tabs>
-      )}
       {content}
     </PageWrapper>
   )

--- a/frontend/src/sharedComponents/ModerationPanel.tsx
+++ b/frontend/src/sharedComponents/ModerationPanel.tsx
@@ -74,6 +74,23 @@ const ModerationPanel = ({
     }
   }, [palette.id, refetch])
 
+  const handleMakePrivate = useCallback(async () => {
+    setIsFetching(true)
+    try {
+      const response = await moderatePalette({
+        paletteId: palette.id,
+        status: MODERATION_STATUS.PRIVATE,
+      })
+      if (response.success) {
+        refetch?.()
+      } else {
+        alert('Failed to moderate palette') // eslint-disable-line
+      }
+    } finally {
+      setIsFetching(false)
+    }
+  }, [palette.id, refetch])
+
   const handleDeleteCallback = useCallback(async () => {
     setIsFetching(true)
     const response = await deletePalette(palette.id)
@@ -130,6 +147,13 @@ const ModerationPanel = ({
         onClick={handleReject}
       >
         Reject
+      </Button>
+      <Button
+        variant="outlined"
+        disabled={isFetching || moderationStatus === MODERATION_STATUS.PRIVATE}
+        onClick={handleMakePrivate}
+      >
+        Make Private
       </Button>
       <Button variant="outlined" disabled={isFetching} onClick={handleDelete}>
         Delete

--- a/frontend/src/sharedComponents/PaletteThumbnail.tsx
+++ b/frontend/src/sharedComponents/PaletteThumbnail.tsx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { useTheme } from '@mui/material/styles'
 import { BORDER_RADIUS, SPACING, subtleBackground } from '../styles/styleConsts'
-import { type TPalette } from '../types'
+import { MODERATION_STATUS, type TPalette } from '../types'
 import { getUserColorFromUUID } from '../utils/getUserColorFromUUID'
 import BlurImage from './BlurImage'
 import ColorBar from './ColorBar'
@@ -100,12 +100,14 @@ const PaletteThumbnail = ({
               {statusChip}
             </Box>
           </Box>
-          <Favorite
-            refetch={refetch}
-            paletteId={palette.id}
-            favorites={palette.favoritesCount}
-            hasUserFavorited={palette.hasUserFavorited}
-          />
+          {palette.moderationStatus !== MODERATION_STATUS.PRIVATE && (
+            <Favorite
+              refetch={refetch}
+              paletteId={palette.id}
+              favorites={palette.favoritesCount}
+              hasUserFavorited={palette.hasUserFavorited}
+            />
+          )}
         </Box>
       </Box>
     </Link>

--- a/frontend/src/sharedComponents/PaletteThumbnail.tsx
+++ b/frontend/src/sharedComponents/PaletteThumbnail.tsx
@@ -12,9 +12,11 @@ import Link from './Link'
 const PaletteThumbnail = ({
   palette,
   refetch,
+  statusChip,
 }: {
   palette: TPalette
   refetch: () => void
+  statusChip?: React.ReactNode
 }) => {
   const theme = useTheme()
 
@@ -91,9 +93,12 @@ const PaletteThumbnail = ({
         >
           <Box>
             <Typography variant="body1">{palette.name}</Typography>
-            <Typography variant="body2">
-              {getUserColorFromUUID(palette.appUserId)}
-            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: SPACING.TINY.PX }}>
+              <Typography variant="body2">
+                {getUserColorFromUUID(palette.appUserId)}
+              </Typography>
+              {statusChip}
+            </Box>
           </Box>
           <Favorite
             refetch={refetch}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -14,12 +14,14 @@ export const MODERATION_STATUS = {
   AWAITING_MODERATION: 0,
   APPROVED: 1,
   REJECTED: 2,
+  PRIVATE: 3,
 }
 
 export const MODERATION_STATUS_LABEL = {
   [MODERATION_STATUS.AWAITING_MODERATION]: 'Pending Approval',
   [MODERATION_STATUS.APPROVED]: 'Approved',
   [MODERATION_STATUS.REJECTED]: 'Rejected',
+  [MODERATION_STATUS.PRIVATE]: 'Private',
 }
 
 export type EModerationStatus =

--- a/scripts/check-backend.sh
+++ b/scripts/check-backend.sh
@@ -22,5 +22,5 @@ echo "Running tests..."
 
 
 # I'm so fucking done. This line is bad. I don't know why. I don't care. It works. Fuck it.
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/photo_palettes PYTHONPATH=. pytest
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/photo_palettes PYTHONPATH=. pytest
 

--- a/scripts/deploy-backend.sh
+++ b/scripts/deploy-backend.sh
@@ -25,10 +25,14 @@ cp -r $COMMON_DIR/common/* $DEPLOY_DIR/common/
 sed 's|^-e git+.*subdirectory=common.*$|-e ./common|' \
     $BACKEND_DIR/requirements.txt > $DEPLOY_DIR/requirements.txt
 
+# Copy database/alembic for migrations
+mkdir -p $DEPLOY_DIR/database
+cp -r database/alembic $DEPLOY_DIR/database/
+cp database/alembic.ini $DEPLOY_DIR/database/
+
 # Copy extra files
 cp $BACKEND_DIR/.python-version $DEPLOY_DIR/ || true
 cp $BACKEND_DIR/.gitignore $DEPLOY_DIR/ || true
-cp Procfile $DEPLOY_DIR/
 
 cd $DEPLOY_DIR
 git init
@@ -40,7 +44,3 @@ cd ..
 rm -rf $DEPLOY_DIR
 
 heroku open --app photo-palettes-backend
-
-echo "Do you need to deploy migrations?"
-echo "Do you need to deploy migrations?"
-echo "Do you need to deploy migrations?"


### PR DESCRIPTION
## Summary
- Palettes now default to **private** (personal library) instead of going to moderation
- Users opt into sharing via a "Share with public" checkbox on Create — shared palettes go to moderation queue
- Profile page: unified list with status chips (Private/Pending/Public/Rejected) replaces tabs
- Palette detail page: full-width "Share with public" / "Make private" buttons for owners
- Favorites hidden on private palettes
- Moderator panel: new "Make Private" button
- About page updated to mention private/public flow
- Auto-run Alembic migrations on Heroku deploy (release phase)
- Fix Docker postgres port conflict (5432→5433) and frontend node_modules volume crash

## Changes

### Backend
- `ModerationStatus.PRIVATE = 3` added + Alembic migration
- `POST /palettes/create` accepts `share_with_public` param (default false)
- `GET /palettes` returns all statuses for profile owner, APPROVED only for others
- `POST /palettes/submit_to_public` — owner can submit private palette to moderation
- `POST /palettes/make_private` — owner can pull any palette back to private
- `POST /palettes/moderate` — moderator can set any status including PRIVATE
- Pushover notifications only fire for public submissions
- Procfile release phase runs `alembic upgrade head`

### Frontend
- `MODERATION_STATUS.PRIVATE` added to types
- Create page: "Share with public" checkbox with helper text, dynamic confirmation message
- Profile page: tabs removed, unified list with Chip status indicators
- Palette detail: info banner for private palettes, full-width "Share with public" / "Make private" button for owner
- PaletteThumbnail + Summary: favorites hidden when palette is private
- ModerationPanel: "Make Private" button
- About page: copy updated for private/public flow

### Infra
- Docker postgres mapped to port 5433 to avoid local postgres conflict
- Frontend Docker volume fix (anonymous volume for node_modules)
- Deploy script copies database/alembic into Heroku bundle
- check-backend.sh uses 127.0.0.1 for DB connection

## Test plan
- [ ] Create palette without "Share with public" → saved as Private, no pushover, no favorites shown
- [ ] Create palette with "Share with public" → goes to moderation queue, pushover fires
- [ ] Own profile shows all palettes with status chips, no tabs
- [ ] Other user profile shows only approved palettes
- [ ] Browse page still shows only approved
- [ ] Private palette detail: info banner, full-width "Share with public" button, no favorites
- [ ] Non-private palette detail: full-width "Make private" button for owner
- [ ] Click "Share with public" → status changes to Pending
- [ ] Click "Make private" → status changes to Private, favorites hidden
- [ ] Moderator can approve, reject, make private, and delete palettes
- [ ] `make deploy-backend` runs migrations automatically