### PR TITLE
Fix Instagram login after stale session

### DIFF
--- a/image-worker/src/instagram.py
+++ b/image-worker/src/instagram.py
@@ -156,8 +156,8 @@ def post_to_instagram(
             # Session expired -> reset and re-login
             client.set_settings({})
             delete_service_session(db_engine, service_name)
+            client.login(config.instagram.username, config.instagram.password)
     else:
-        # No valid session, so login fresh
         client.login(config.instagram.username, config.instagram.password)
 
     # Save latest session back to DB


### PR DESCRIPTION
## Summary
- When a stored Instagram session was invalid, the code cleared it but never called `login()` again, leaving the client unauthenticated — causing `login_required` / `PhotoNotUpload` errors on upload.

## Test plan
- [ ] Clear Instagram session from `service_session` table
- [ ] Trigger an Instagram post task and verify it re-authenticates and uploads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)